### PR TITLE
Severity change

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    slogger (0.0.9)
+    slogger (0.0.10)
 
 GEM
   remote: http://rubygems.org/

--- a/lib/slogger/base.rb
+++ b/lib/slogger/base.rb
@@ -109,9 +109,9 @@ module Slogger
 
     def severity=(value)
       raise_argument_error_to_invalid_parameter "severity", "SEVERITIES" unless @custom_severity_levels[value]
-      
+
       @severity = value
-      @severity_as_int = @custom_severity_levels[severity]
+      @severity_as_int = @custom_severity_levels[@severity]
     end
 
     def log(severity, message, &block)

--- a/spec/slogger/common_logger_spec.rb
+++ b/spec/slogger/common_logger_spec.rb
@@ -74,6 +74,11 @@ describe Slogger::CommonLogger do
     it "should raise ArgumentError if try to change severity attribute to a invalid one" do
       lambda { subject.severity = :junk }.should raise_error
     end
+
+    it "should still log after severity is set to warn" do
+      subject.severity = :warn
+      expect { subject.debug("Hello Logs!") }.not_to raise_error
+    end
   end
 
   describe "logging" do


### PR DESCRIPTION
Hi there! We've been using slogger in production for a while and it's pretty great.

We found out that logging after changing the severity to `:warn` raises an error (see spec added in the first commit). We have a small workaround for this, but this PR should fix things. :)

The first commit adds a test that reproduces the bug and the second is the fix. Let me know if you want me to change anything.

And thanks for building slogger btw!